### PR TITLE
#656 [TimeSheet] fix: broken lock button condition

### DIFF
--- a/view/timesheet/timesheet_card.php
+++ b/view/timesheet/timesheet_card.php
@@ -840,7 +840,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
             // Lock.
             $displayButton = $onPhone ? '<i class="fas fa-lock fa-2x"></i>' : '<i class="fas fa-lock"></i>' . ' ' . $langs->trans('Lock');
-            if ($object->status == TimeSheet::STATUS_VALIDATED && $signatory->checkSignatoriesSignatures($object->id, $object->element) && (getDolGlobalInt('DOLISIRH_ALLOW_DIFFERENCE_BETWEEN_PASSED_AND_WORKING_HOURS') ? $diffTotalTime == 0 : '')) {
+            if ($object->status == TimeSheet::STATUS_VALIDATED && $signatory->checkSignatoriesSignatures($object->id, $object->element) && (getDolGlobalInt('DOLISIRH_ALLOW_DIFFERENCE_BETWEEN_PASSED_AND_WORKING_HOURS') || $diffTotalTime == 0)) {
                 print '<span class="butAction" id="actionButtonLock">' . $displayButton . '</span>';
             } else {
                 print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('AllSignatoriesMustHaveSignedAndDiffTimeSetAt0')) . '">' . $displayButton . '</span>';


### PR DESCRIPTION
Fix #656.

La condition d'activation du bouton Lock dans `view/timesheet/timesheet_card.php` utilisait un ternaire inversé qui empêchait tout verrouillage en mode strict (constante désactivée → résultat `''`) et exigeait au contraire `diff == 0` quand la constante autorisait la différence.

Remplacement par un OR :

```diff
-(getDolGlobalInt('DOLISIRH_ALLOW_DIFFERENCE_BETWEEN_PASSED_AND_WORKING_HOURS') ? $diffTotalTime == 0 : '')
+(getDolGlobalInt('DOLISIRH_ALLOW_DIFFERENCE_BETWEEN_PASSED_AND_WORKING_HOURS') || $diffTotalTime == 0)
```

→ si la constante autorise la différence on lock peu importe le diff, sinon on exige `diff == 0`.

Régression introduite par #631.