### PR TITLE
#659 [DolisirhTriggers] fix: cannot modify header information warning during module activation

### DIFF
--- a/core/triggers/interface_99_modDolisirh_DolisirhTriggers.class.php
+++ b/core/triggers/interface_99_modDolisirh_DolisirhTriggers.class.php
@@ -138,14 +138,20 @@ class InterfaceDoliSIRHTriggers extends DolibarrTriggers
                                 $name_message = $task->ref;
 
                                 $task->addTimeSpent($user);
-                                setEventMessages($langs->trans('MessageTimeSpentCreate') . ' : ' . '<a href="' . DOL_URL_ROOT . '/projet/tasks/time.php?id=' . $id_message . '">' . $name_message.'</a>', []);
+                                if (!headers_sent()) {
+                                    setEventMessages($langs->trans('MessageTimeSpentCreate') . ' : ' . '<a href="' . DOL_URL_ROOT . '/projet/tasks/time.php?id=' . $id_message . '">' . $name_message . '</a>', []);
+                                }
                             } else {
-                                setEventMessages($task->error, $task->errors, 'errors');
+                                if (!headers_sent()) {
+                                    setEventMessages($task->error, $task->errors, 'errors');
+                                }
                                 return -1;
                             }
                         }
                     } else {
-                        setEventMessages($ticket->error, $ticket->errors, 'errors');
+                        if (!headers_sent()) {
+                            setEventMessages($ticket->error, $ticket->errors, 'errors');
+                        }
                         return -1;
                     }
                 }
@@ -173,24 +179,36 @@ class InterfaceDoliSIRHTriggers extends DolibarrTriggers
                             }
 
                             if ($result > 0) {
-                                setEventMessages($langs->trans('MessageTimeSpentCreate') . ' : ' . '<a href="' . DOL_URL_ROOT . '/projet/tasks/time.php?id=' . $idMessage . '">' . $nameMessage . '</a>', []);
+                                if (!headers_sent()) {
+                                    setEventMessages($langs->trans('MessageTimeSpentCreate') . ' : ' . '<a href="' . DOL_URL_ROOT . '/projet/tasks/time.php?id=' . $idMessage . '">' . $nameMessage . '</a>', []);
+                                }
                             } else {
-                                setEventMessages($task->error, $task->errors, 'errors');
+                                if (!headers_sent()) {
+                                    setEventMessages($task->error, $task->errors, 'errors');
+                                }
                                 return -1;
                             }
                         } else {
-                            setEventMessages($langs->trans('ErrorUserNotAssignedToTask'), $task->errors, 'errors');
+                            if (!headers_sent()) {
+                                setEventMessages($langs->trans('ErrorUserNotAssignedToTask'), $task->errors, 'errors');
+                            }
                             return -1;
                         }
                     } else {
-                        setEventMessages($task->error, $task->errors, 'errors');
+                        if (!headers_sent()) {
+                            setEventMessages($task->error, $task->errors, 'errors');
+                        }
                         return -1;
                     }
                 } elseif ($object->element == 'action' && !empty($object->array_options['options_timespent']) && $object->array_options['options_timespent'] == 1 && $object->elementtype != 'task') {
-                    setEventMessages('MissingTaskWithTimeSpentOption', $object->errors, 'errors');
+                    if (!headers_sent()) {
+                        setEventMessages('MissingTaskWithTimeSpentOption', $object->errors, 'errors');
+                    }
                     return -1;
                 } elseif ($object->element == 'action' && !empty($object->array_options['options_timespent']) && $object->array_options['options_timespent'] == 1 && empty($object->datef)) {
-                    setEventMessages('MissingEndDateWithTimeSpentOption', $object->errors, 'errors');
+                    if (!headers_sent()) {
+                        setEventMessages('MissingEndDateWithTimeSpentOption', $object->errors, 'errors');
+                    }
                     return -1;
                 }
                 break;


### PR DESCRIPTION
## Description

`Cannot modify header information - headers already sent` warning thrown during module activation.

## Warning

```
Warning: Cannot modify header information - headers already sent by
(output started at core/triggers/interface_99_modDolisirh_DolisirhTriggers.class.php:152)
in htdocs/admin/modules.php on line 473
```

## Root cause

In the `ACTION_CREATE` case of `runTrigger()`, several `setEventMessages()` calls are made unconditionally. When the module is activated via `activateModule()`, this trigger can be fired before HTTP headers are finalized. Any `setEventMessages()` call writes to `$_SESSION` which may implicitly send headers, causing the subsequent `header('Location:...')` in `modules.php:473` to fail with the above warning.

## Fix

Wrap every `setEventMessages()` call inside the `ACTION_CREATE` case with a `!headers_sent()` guard:

```php
if (!headers_sent()) {
    setEventMessages(...);
}
```

This is safe because:
- The message is only useful in a browser context anyway
- `return -1` is preserved for error propagation
- No functional logic is changed
