### PR TITLE
#661 [Timesheet] fix: sticky left column z-index to prevent hours bleed-through

### DIFF
--- a/lib/dolisirh_timespent.lib.php
+++ b/lib/dolisirh_timespent.lib.php
@@ -703,7 +703,7 @@ function task_lines_within_range(int &$inc, int $timestampStart, int $timestampE
                 print '<tr class="oddeven" data-task_id="' . $lines[$i]->id . '" >';
 
                 // Ref.
-                print '<td class="nowrap" style="position: sticky; left: 0; background-color: #FFFFFF;">';
+                print '<td class="nowrap" style="position: sticky; left: 0; background-color: #FFFFFF; z-index: 500;">';
                 print '<!-- Task id = ' . $lines[$i]->id . ' -->';
                 for ($k = 0; $k < $level; $k++) {
                     print '<div class="marginleftonly">';

--- a/view/timespent_range.php
+++ b/view/timespent_range.php
@@ -563,7 +563,7 @@ print '</td>';
 print '</tr>';
 
 print '<tr class="liste_titre">';
-print '<th style="position: sticky; left: 0; background-color: var(--colorbacktitle1); z-index: 1040;>' . $form->textwithpicto($langs->trans('Task'), $tooltipTaskInfo);
+print '<th style="position: sticky; left: 0; background-color: var(--colorbacktitle1); z-index: 1040;">' . $form->textwithpicto($langs->trans('Task'), $tooltipTaskInfo);
 print ' <i class="fas fa-star"></i>';
 print '<input type="checkbox"  class="show-only-favorite-tasks"' . ($user->conf->DOLISIRH_SHOW_ONLY_FAVORITE_TASKS ? ' checked' : '') . '>';
 print $form->textwithpicto('', $langs->trans('ShowOnlyFavoriteTasks'));


### PR DESCRIPTION
## Contexte

Sur la vue feuille de temps mensuelle (`view/timespent_range.php`), la première colonne (nom de tâche) est en `position: sticky; left: 0` pour rester visible lors du défilement horizontal. Sa cellule de corps avait un fond blanc opaque **mais aucun `z-index`**.

Les cellules de jour contiennent des éléments positionnés (wrappers de tooltip `.wpeo-tooltip-event`). La cellule sticky et ces wrappers étant tous en `z-index: auto`, l'ordre du DOM décidait de l'empilement : les cellules de jour, plus tardives dans le DOM, s'affichaient **par-dessus** la colonne de gauche. Les heures posées « transparaissaient » donc sur les noms de tâches (cf. issue #661).

## Changements

- `lib/dolisirh_timespent.lib.php` : ajout de `z-index: 500` sur la cellule sticky du nom de tâche (corps du tableau), pour qu'elle masque proprement les cellules de jour qui défilent en dessous. Valeur volontairement inférieure au `z-index: 1040` de l'en-tête/pied sticky, qui doivent rester au-dessus lors du défilement vertical.
- `view/timespent_range.php` : correction d'un guillemet fermant manquant dans l'attribut `style` de l'en-tête `<th>` sticky (`z-index: 1040;>` → `z-index: 1040;">`), même mécanisme de colonne sticky.

## Fichiers modifiés

- `lib/dolisirh_timespent.lib.php`
- `view/timespent_range.php`

## Issue

#661
