### PR TITLE
#663 [Timesheet] fix: escape timespent comment in tooltip aria-label

### DIFF
--- a/lib/dolisirh_timespent.lib.php
+++ b/lib/dolisirh_timespent.lib.php
@@ -802,7 +802,7 @@ function task_lines_within_range(int &$inc, int $timestampStart, int $timestampE
 
                     $tableCell = '<td class="center ' . $idw . ' ' . $cellCSS . '" data-cell="' . $idw . '">';
                     if ($alreadySpent) {
-                        $tableCell .= '<span class="timesheetalreadyrecorded wpeo-tooltip-event" aria-label="' . $textTooltip . '"><input type="text" class="center smallpadd" size="2" disabled id="timespent[' . $inc . '][' . $idw . ']" name="task[' . $lines[$i]->id . '][' . $idw . ']" value="' . $alreadySpent . '"></span>';
+                        $tableCell .= '<span class="timesheetalreadyrecorded wpeo-tooltip-event" aria-label="' . dol_escape_htmltag($textTooltip) . '"><input type="text" class="center smallpadd" size="2" disabled id="timespent[' . $inc . '][' . $idw . ']" name="task[' . $lines[$i]->id . '][' . $idw . ']" value="' . $alreadySpent . '"></span>';
                     }
 
                     $tableCell .= '<div class="modal-open">';


### PR DESCRIPTION
## Changements
- Échappement du commentaire de pointage (`timespent_note`) via `dol_escape_htmltag()` avant son injection dans l'attribut `aria-label` de la tooltip.
- Corrige le bug où le texte du commentaire s'affichait directement dans la grille : quand la note contient un guillemet ou un caractère HTML (`"`, `<`, `>`), l'attribut `aria-label` était fermé prématurément et le reste du texte « fuyait » dans la page.
- La tooltip (`saturne/js/modules/tooltip.js`) relit `aria-label` et re-décode automatiquement les entités : la bulle au survol affiche donc toujours le bon texte.
- `task_lines_within_range()` étant partagée par les vues **mois / semaine / jour**, le correctif couvre les trois.

## Fichiers modifiés
- `lib/dolisirh_timespent.lib.php`

## Issue
#663
