### PR TITLE
fix: #665 use raw SQL syntax in get_full_tree filter

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -106,7 +106,7 @@ if (GETPOST('create_hr_project_tasks', 'alpha')) {
 
         if ($projectID > 0 && $error == 0) {
             dolibarr_set_const($db, 'DOLISIRH_HR_PROJECT', $projectID, 'integer', 0, '', $conf->entity);
-            $users = $userTmp->get_full_tree(0, '((u.employee:=:1) AND (u.fk_soc:is:NULL) AND (u.statut:=:1))');
+            $users = $userTmp->get_full_tree(0, '((u.employee = 1) AND (u.fk_soc IS NULL) AND (u.statut = 1))');
             if (!empty($users) && is_array($users)) {
                 foreach ($users as $userSingle) {
                     $project->add_contact($userSingle['id'], 'PROJECTCONTRIBUTOR', 'internal');


### PR DESCRIPTION
## Fixes #665

### Problem

`admin/setup.php` line 109 passes Dolibarr natural filter syntax (`:=:`, `:is:`) to `User::get_full_tree()`, but this method concatenates the filter directly into the SQL query, causing a `DB_ERROR_SYNTAX`.

### Change

Replace:
```
(u.employee:=:1) AND (u.fk_soc:is:NULL) AND (u.statut:=:1)
```

With standard SQL:
```
(u.employee = 1) AND (u.fk_soc IS NULL) AND (u.statut = 1)
```

### File changed
- `admin/setup.php` (1 line)